### PR TITLE
add decorator which forces django template admin

### DIFF
--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/base.py
@@ -211,7 +211,7 @@ TEMPLATES = [
         # https://docs.djangoproject.com/en/dev/ref/settings/#std:setting-TEMPLATES-BACKEND
         "BACKEND": "django.template.backends.django.DjangoTemplates",
         # https://docs.djangoproject.com/en/dev/ref/settings/#template-dirs
-        "DIRS": [APP_DIR / "templates"],
+        "DIRS": [APP_DIR / "dtl_templates"],
         "OPTIONS": {
             # https://docs.djangoproject.com/en/dev/ref/settings/#template-loaders
             # https://docs.djangoproject.com/en/dev/ref/templates/api/#loader-types

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/home/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/home/admin.py
@@ -1,0 +1,44 @@
+from allauth.account.models import EmailAddress
+from django.contrib.auth.admin import admin
+from django.contrib.auth.models import Group
+from django.contrib.sites.models import Site
+from robots.admin import RuleAdmin
+from robots.models import Rule, Url
+
+from testhydra.util.admin import force_django_template
+
+admin.site.unregister(Rule)
+admin.site.unregister(Url)
+admin.site.unregister(Site)
+admin.site.unregister(Group)
+admin.site.unregister(EmailAddress)
+
+
+@admin.register(Rule)
+@force_django_template
+class CustomRuleAdmin(RuleAdmin):
+    pass
+
+
+@admin.register(Url)
+@force_django_template
+class UrlAdmin(admin.ModelAdmin):
+    pass
+
+
+@admin.register(Site)
+@force_django_template
+class SiteAdmin(admin.ModelAdmin):
+    pass
+
+
+@admin.register(Group)
+@force_django_template
+class GroupAdmin(admin.ModelAdmin):
+    pass
+
+
+@admin.register(EmailAddress)
+@force_django_template
+class EmailAdmin(admin.ModelAdmin):
+    pass

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/home/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/home/admin.py
@@ -5,7 +5,7 @@ from django.contrib.sites.models import Site
 from robots.admin import RuleAdmin
 from robots.models import Rule, Url
 
-from testhydra.util.admin import force_django_template
+from {{cookiecutter.repo_name}}.util.admin import force_django_template
 
 admin.site.unregister(Rule)
 admin.site.unregister(Url)

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/util/admin.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/util/admin.py
@@ -1,5 +1,69 @@
-# from django.contrib import admin  # noqa
+from django.contrib.admin.decorators import display
+from django.contrib.admin.options import helpers
+from django.contrib.auth.admin import admin
+from django.forms.renderers import DjangoTemplates
+from django.template.base import mark_safe
 
-# from .models import TestFileModel  # noqa
 
-# admin.site.register(TestFileModel) # noqa
+def force_django_template(AdminClass: type[admin.ModelAdmin]):
+    """ Replaces your admin class with one which forces the use of the DjangoTemplates renderer
+        Noted exceptions:
+            - sub-widgets rendered by the RelatedFieldWidgetWrapper
+        Usage:
+            @admin.register(MyModel)
+            @force_django_template
+            class MyModelAdmin(admin.ModelAdmin):
+                ...
+    """
+    action_form_class = None
+    if ActionFormClass := getattr(AdminClass, "action_form", None):
+
+        class ForcedDjangoActionForm(ActionFormClass):
+            default_renderer = DjangoTemplates()
+
+        action_form_class = ForcedDjangoActionForm
+
+    def get_form(self, request, obj=None, change=False, **kwargs):
+        form = AdminClass.get_form(self, request, obj=obj, change=change, **kwargs)
+        form.default_renderer = DjangoTemplates()
+        return form
+
+    def changelist_view(self, request, extra_context=None):
+        template_response = AdminClass.changelist_view(
+            self, request, extra_context=extra_context
+        )
+        template_response.using = "django"
+        return template_response
+
+    def get_changelist_form(self, request, **kwargs):
+        Form = AdminClass.get_changelist_form(self, request, **kwargs)
+        Form.renderer = DjangoTemplates()
+        return Form
+
+    def get_changelist_formset(self, request, **kwargs):
+        FormSet = AdminClass.get_changelist_formset(self, request, **kwargs)
+        FormSet.renderer = DjangoTemplates()
+        return FormSet
+
+    @display(description=mark_safe('<input type="checkbox" id="action-toggle">'))
+    def action_checkbox(self, obj):
+        """
+        A list_display column containing a checkbox widget.
+        """
+        del self
+        return helpers.checkbox.render(
+            helpers.ACTION_CHECKBOX_NAME, str(obj.pk), renderer=DjangoTemplates()
+        )
+
+    return type(
+        f"{AdminClass.__name__}_forceddjangotemplates",
+        (AdminClass,),
+        {
+            "get_form": get_form,
+            "action_form": action_form_class,
+            "changelist_view": changelist_view,
+            "get_changelist_form": get_changelist_form,
+            "get_changelist_formset": get_changelist_formset,
+            "action_checkbox": action_checkbox,
+        },
+    )


### PR DESCRIPTION
# Known exceptions to PR
https://github.com/django/django/blob/b7a17b0ea0a2061bae752a3a2292007d41825814/django/contrib/admin/widgets.py#L245
Any field rendered through this widget wrapper. I have not found a sane way to inject a renderer into this

# Dead Ends
Here are some dead ends I went down, preserved here so I feel better about the time spent
## overwrite jinja renderer
example:
```py
class Jinja3(Jinja2):
    def get_template(self, template_name):
        template = super().get_template(template_name)
        if [is admin template]:
            raise TemplateDoesNotExist
        return template
```
### problem:
At this point in the code there is no context for whether the template is being rendered *inside* an admin template. The base admin templates include `"admin/"` in their path, but the sub-templates (e.g. fields) they render do not. You don't have any more helpful context here than is given to the regex which is *already* filtering out base admin templates correctly.

However for debugging purposes something like this is helpful for identifying the templates that have fallen into jinja2-land
```py
class JinjaSnitch(Jinja2):
    def get_template(self, template_name):
        print("^^^ Jinja template attempt", template_name)
        template = super().get_template(template_name)
        print(
            "     ~#~#~#~#~#~#~#~#~#~#~#~ jinja template was used  ~#~#~#~#~#~#~#~#~#~#~#~ "
        )
        return template
```

## A loathsome global
example:
```py
from django.template import loader


class Jinja2Custom(Jinja2):
    def render(self, template_name, context, request=None):
        global is_admin
        if is_admin:
            raise TemplateDoesNotExist
        template = self.get_template(template_name)
        return template.render(context, request=request).strip()


old_select = loader.select_template


def select_template(template_name, using=None):
    global is_admin
    if isinstance(template_name, str):
        # imagine a regex here instead
        is_admin = "admin" in template_name
    elif isinstance(template_name, list):
        is_admin = any(["admin" in template for template in template_name])
    return old_select(template_name, using=using)


setattr(loader, "select_template", select_template)
```

### problem
This "works" in contrived local testing. However...
Globals are a code-smell on their own. And in this case I believe this would cause all kinds of nonsense in an async environment.  

Notice also the `using=None` kwarg in the `select_template` function? That seemed promising, but django does not pass this value from anywhere sane, and in many cases passes no value. It's either a vestigial or overly-hopeful feature.

## Keep you in django template land once you find yourself there
example
```py
class WalledEngine(Engine):
    def find_template(self, name, dirs=None, skip=None):
        del dirs
        tried = []
        for loader in self.template_loaders:
            try:
                template = loader.get_template(name, skip=skip, using="django")
                return template, template.origin
            except TemplateDoesNotExist as e:
                tried.extend(e.tried)
        raise TemplateDoesNotExist(name, tried=tried)


class WalledDjangoTemplates(DjangoTemplates):
    def __init__(self, params):
        # overridden to set custom engine
        copy_params = params.copy()
        super().__init__(params)
        options = copy_params.pop("OPTIONS").copy()
        options.setdefault("autoescape", True)
        options.setdefault("debug", DEBUG)
        options.setdefault("file_charset", "utf-8")
        libraries = options.get("libraries", {})
        options["libraries"] = self.get_templatetag_libraries(libraries)
        self.engine = WalledEngine(self.dirs, self.app_dirs, **options)
```
### problem
This was only a half-hearted attempt as mentioned above, django admin rarely passes any information about previously used renderers down to sub templates. It effectively does not matter how the parent template was rendered.

# Other Notes
Throughout this whole process it has felt like I was just missing something especially around
https://github.com/django/django/blob/b7a17b0ea0a2061bae752a3a2292007d41825814/django/template/loader.py#L22
(and get_template above that)
Like there was some cleaner way to cut the gordion knot that I just wasn't seeing.

Digging into this problem has soured me a bit in general regarding django admin. There's a lot more competing organization and patterns than I had thought.
