### PR TITLE
reducing number of vite entry points

### DIFF
--- a/{{cookiecutter.repo_name}}/vite.config.js
+++ b/{{cookiecutter.repo_name}}/vite.config.js
@@ -21,10 +21,7 @@ export default defineConfig({
         /* The bundle's entry point(s).  If you provide an array of entry points or an object mapping names to
         entry points, they will be bundled to separate output chunks. */
         components: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/components.ts'),
-        account: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/account.ts'),
-        forms: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/forms.ts'),
         main: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/main.ts'),
-        links: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/js/links.ts'),
         styles: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/css/styles.js'),
         raw_tailwind: resolve(__dirname, './{{cookiecutter.repo_name}}/static_source/css/tailwind.js'),
       }

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/base.py
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/config/settings/base.py
@@ -263,6 +263,7 @@ CORS_ALLOWED_ORIGINS = []
 CSP_SCRIPT_SRC = [
     "'self'",
     "'unsafe-eval'",
+    "'unsafe-inline'",
 ]
 # data: from tailwind form plugin + tomselect
 CSP_IMG_SRC = ["'self'", "data:", "https:"]

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/account.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/account.ts
@@ -1,2 +1,0 @@
-import.meta.glob("@/../templates/account/**/*.js", { eager: true });
-import.meta.glob("@/../templates/account/**/*.ts", { eager: true });

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/components.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/components.ts
@@ -1,2 +1,10 @@
 import.meta.glob("@/../templates/components/**/*.js", { eager: true });
 import.meta.glob("@/../templates/components/**/*.ts", { eager: true });
+
+// account
+import.meta.glob("@/../templates/account/**/*.js", { eager: true });
+import.meta.glob("@/../templates/account/**/*.ts", { eager: true });
+
+// forms
+import.meta.glob("@/../templates/forms/**/*.js", { eager: true });
+import.meta.glob("@/../templates/forms/**/*.ts", { eager: true });

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/forms.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/forms.ts
@@ -1,2 +1,0 @@
-import.meta.glob("@/../templates/forms/**/*.js", { eager: true });
-import.meta.glob("@/../templates/forms/**/*.ts", { eager: true });

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/main.ts
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/static_source/js/main.ts
@@ -6,18 +6,20 @@ import htmx from "htmx.org";
 import Alpine from "alpinejs";
 import Cookies from "js-cookie";
 
+import "./links.ts";
+
 if (import.meta.env.MODE !== "development") {
   // // @ts-expect-error  // this whole system is broken w/ vite
   // import("vite/modulepreload-polyfill"); // eslint-disable-line import/no-unresolved
   // https://github.com/vitejs/vite/issues/4786
 }
 
-
-
 htmx.defineExtension("get-csrf", {
   onEvent(name: string, evt: any) {
     if (name === "htmx:configRequest") {
-      evt.detail.headers["X-CSRFToken"] = Cookies.get("{{cookiecutter.repo_name}}_csrftoken");
+      evt.detail.headers["X-CSRFToken"] = Cookies.get(
+        "{{cookiecutter.repo_name}}_csrftoken"
+      );
     }
   },
 });

--- a/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.jinja
+++ b/{{cookiecutter.repo_name}}/{{cookiecutter.repo_name}}/templates/base.jinja
@@ -18,10 +18,7 @@
         <link rel="icon" href={{ static("img/favicons/favicon.ico") }} />
         {{ vite_hmr_client() }}
         {{ vite_asset('css/styles.js') }}
-        {{ vite_asset('js/account.ts') }}
         {{ vite_asset('js/components.ts') }}
-        {{ vite_asset('js/forms.ts') }}
-        {{ vite_asset('js/links.ts') }}
         {{ vite_asset('js/main.ts') }}
         {{ django_htmx_script() }}
         <title>


### PR DESCRIPTION
Reducing the number of entry points to reduce overall number of files to load on init for the browser.

Also noticed a bug in firefox with script src inline injection. Seems that chrome is cool with that. I added it as a setting to base.py but I'm not 100% clear on the security implications of adding that globally. Without it, the register form can't submit.